### PR TITLE
chore: remove redundant interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockingbird-ts",
-  "version": "1.5.0",
+  "version": "1.1.0-next.1",
   "license": "MIT",
   "description": "Super Simple, Yet Powerful, TypeScript Library for Creating Mocks",
   "keywords": [

--- a/src/class-processor.ts
+++ b/src/class-processor.ts
@@ -6,13 +6,16 @@ import { ArrayValueHandler } from './handlers/array-value-handler';
 import { SingleClassValueHandler } from './handlers/single-class-value-handler';
 import { PrimitiveValueHandler } from './handlers/primitive-value-handler';
 import { ClassLiteral, Class, MockOptions } from './types/mock-options.type';
-import { IProperty } from './types/iproperty.interface';
+import { Property } from './property';
 import { ValueHandler } from './types/value-handler.interface';
-import { IClassProcessor } from './types/iclass-processor.interface';
 
 import FakerStatic = Faker.FakerStatic;
 
-export class ClassProcessor<T> implements IClassProcessor<T> {
+export interface ClassProcessor<T> {
+  process(target: Class<T>): ClassLiteral<T>;
+}
+
+export class ClassProcessor<T> implements ClassProcessor<T> {
   private static readonly VALUE_INSPECTORS: Class<ValueHandler<MockOptions>>[] = [
     EnumValueHandler,
     ArrayValueHandler,
@@ -28,7 +31,7 @@ export class ClassProcessor<T> implements IClassProcessor<T> {
     this.faker.setLocale(locale);
   }
 
-  private handlePropertyValue(property: IProperty<MockOptions>): T | T[] {
+  private handlePropertyValue(property: Property<MockOptions>): T | T[] {
     for (const inspectorClass of ClassProcessor.VALUE_INSPECTORS) {
       const inspector = new inspectorClass(this.faker, this) as ValueHandler<MockOptions>;
 

--- a/src/class-reflector.ts
+++ b/src/class-reflector.ts
@@ -2,14 +2,13 @@ import reflect, { ClassReflection, PropertyReflection } from '@plumier/reflect';
 import { Class } from './types/mock-options.type';
 import { MockOptions } from './types/mock-options.type';
 import { MOCK_DECORATOR_NAME } from './decorators/mock.decorator';
-import { IProperty } from './types/iproperty.interface';
-import { ClassReflectionDto } from './types/class-reflection-dto.type';
 import { Property } from './property';
+import { ClassReflectionDto } from './types/class-reflection-dto.type';
 
 export class ClassReflector {
   public static readonly REFLECTED_CLASSES: Record<string, ClassReflectionDto> = {};
 
-  private extractDecoratedProperties(classReflection: ClassReflection): IProperty<MockOptions>[] {
+  private extractDecoratedProperties(classReflection: ClassReflection): Property<MockOptions>[] {
     return classReflection.properties.map((property) => {
       const value = ClassReflector.extractMockDecoratorValue(property);
 

--- a/src/factories/mock-factory.ts
+++ b/src/factories/mock-factory.ts
@@ -49,7 +49,6 @@ export class MockFactory {
     options?: MockDecoratorFactoryOptions
   ): ClassLiteral<TClass> | ClassLiteral<TClass>[] {
     const { count = 1, locale = ClassProcessor.DEFAULT_LOCALE } = options || {};
-
     const factory = new ClassProcessor<TClass>(faker, new ClassReflector(), locale);
 
     if (!count || count === 1) {

--- a/src/handlers/array-value-handler.test.ts
+++ b/src/handlers/array-value-handler.test.ts
@@ -1,4 +1,3 @@
-import { IProperty } from '../types/iproperty.interface';
 import { ArrayValueHandler } from './array-value-handler';
 import { ClassProcessor } from '../class-processor';
 import { MultiClass } from '../types/mock-options.type';
@@ -12,7 +11,7 @@ describe('ArrayValueHandler Unit', () => {
 
   let handler: ArrayValueHandler<MultiClass>;
 
-  function createProperty(mockValue: MultiClass): IProperty<MultiClass> {
+  function createProperty(mockValue: MultiClass): Property<MultiClass> {
     return new Property('testPropertyName', 'TestClass', new PropertyDecoratorValue<MultiClass>(mockValue));
   }
 
@@ -47,7 +46,7 @@ describe('ArrayValueHandler Unit', () => {
 
     describe("when calling 'produceValue' method", () => {
       describe('and the decoratorValue is null', () => {
-        test('return null', () => {
+        test('then return null', () => {
           expect(handler.produceValue(createProperty(null))).toBeNull();
         });
       });

--- a/src/handlers/array-value-handler.ts
+++ b/src/handlers/array-value-handler.ts
@@ -1,5 +1,4 @@
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
 import { ExactValue, Class, MultiClass } from '../types/mock-options.type';
 import { PrimitiveHandlerAbstract } from './primitive-handler-abstract';
 import { Property } from '../property';
@@ -7,7 +6,7 @@ import { isPrimitive } from '../common/is-primitive';
 
 // TODO: refactor (2nd phase). All other mock options should be wrapped with 'multiple' functionality
 export class ArrayValueHandler<P extends MultiClass> extends PrimitiveHandlerAbstract<P> implements ValueHandler<P> {
-  public shouldHandle(property: IProperty<P>): boolean {
+  public shouldHandle(property: Property<P>): boolean {
     return property.decoratorValue.isMultiClass();
   }
 

--- a/src/handlers/callback-value-handler.ts
+++ b/src/handlers/callback-value-handler.ts
@@ -1,14 +1,14 @@
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { Callback } from '../types/mock-options.type';
 import { AbstractValueHandler } from './abstract-value-handler';
 
 export class CallbackValueHandler<P extends Callback> extends AbstractValueHandler implements ValueHandler<P> {
-  public shouldHandle(property: IProperty<P>): boolean {
+  public shouldHandle(property: Property<P>): boolean {
     return property.decoratorValue.isCallback() && (property.decoratorValue.value as Callback).name === '';
   }
 
-  public produceValue<T>(property: IProperty<P>): any {
+  public produceValue<T>(property: Property<P>): any {
     return (property.decoratorValue.value as Callback)(this.faker);
   }
 }

--- a/src/handlers/enum-value-handler.ts
+++ b/src/handlers/enum-value-handler.ts
@@ -1,5 +1,5 @@
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { EnumObject } from '../types/mock-options.type';
 import { AbstractValueHandler } from './abstract-value-handler';
 
@@ -20,11 +20,11 @@ export class EnumValueHandler<P extends EnumObject> extends AbstractValueHandler
     return valuesList;
   }
 
-  public shouldHandle(propertyDto: IProperty<P>): boolean {
+  public shouldHandle(propertyDto: Property<P>): boolean {
     return propertyDto.decoratorValue.isEnum();
   }
 
-  public produceValue<T>(propertyDto: IProperty<P>): any {
+  public produceValue<T>(propertyDto: Property<P>): any {
     const {
       decoratorValue: { value },
     } = propertyDto;

--- a/src/handlers/object-literal-value-handler.test.ts
+++ b/src/handlers/object-literal-value-handler.test.ts
@@ -2,10 +2,9 @@ import { ObjectLiteralValueHandler } from '../handlers/object-literal-value-hand
 import { ObjectLiteral } from '../types/mock-options.type';
 import { Property } from '../property';
 import { PropertyDecoratorValue } from '../property-decorator-value';
-import { IProperty } from '../types/iproperty.interface';
 
 describe('ObjectLiteralValueInspector Unit', () => {
-  let property: IProperty<ObjectLiteral>, handler: ObjectLiteralValueHandler<ObjectLiteral>;
+  let property: Property<ObjectLiteral>, handler: ObjectLiteralValueHandler<ObjectLiteral>;
   const OBJECT_LITERAL_VALUE = { testArbitrary: 'and-arbitrary-decoratorValue' };
 
   describe('given a ObjectLiteralValueInspector', () => {

--- a/src/handlers/object-literal-value-handler.ts
+++ b/src/handlers/object-literal-value-handler.ts
@@ -1,17 +1,17 @@
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { ObjectLiteral } from '../types/mock-options.type';
 import { AbstractValueHandler } from './abstract-value-handler';
 
 export class ObjectLiteralValueHandler<P extends ObjectLiteral>
   extends AbstractValueHandler
   implements ValueHandler<P> {
-  public shouldHandle(property: IProperty<P>): boolean {
+  public shouldHandle(property: Property<P>): boolean {
     const { decoratorValue } = property;
     return decoratorValue.isObject() && !decoratorValue.isMultiClass() && !decoratorValue.isEnum();
   }
 
-  public produceValue<T>(propertyDto: IProperty<P>): any {
+  public produceValue<T>(propertyDto: Property<P>): any {
     return propertyDto.decoratorValue.value;
   }
 }

--- a/src/handlers/primitive-handler-abstract.ts
+++ b/src/handlers/primitive-handler-abstract.ts
@@ -1,4 +1,4 @@
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { ExactValue, MockOptions } from '../types/mock-options.type';
 
 import { AbstractValueHandler } from './abstract-value-handler';
@@ -21,7 +21,7 @@ export abstract class PrimitiveHandlerAbstract<P extends MockOptions> extends Ab
     }
   }
 
-  public isPrimitive(propertyDto: IProperty<P>): boolean {
+  public isPrimitive(propertyDto: Property<P>): boolean {
     return isPrimitive(propertyDto.constructorName) && !propertyDto.decoratorValue.isCallback();
   }
 }

--- a/src/handlers/primitive-value-handler.ts
+++ b/src/handlers/primitive-value-handler.ts
@@ -1,16 +1,16 @@
 import { PrimitiveHandlerAbstract } from './primitive-handler-abstract';
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { ExactValue } from '../types/mock-options.type';
 
 export class PrimitiveValueHandler<P extends ExactValue>
   extends PrimitiveHandlerAbstract<P>
   implements ValueHandler<P> {
-  public shouldHandle(property: IProperty<P>): boolean {
+  public shouldHandle(property: Property<P>): boolean {
     return this.isPrimitive(property);
   }
 
-  public produceValue<T>(property: IProperty<P>): any {
+  public produceValue<T>(property: Property<P>): any {
     const { decoratorValue } = property;
 
     if (typeof decoratorValue.value !== 'undefined') {

--- a/src/handlers/single-class-value-handler.test.ts
+++ b/src/handlers/single-class-value-handler.test.ts
@@ -1,17 +1,16 @@
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { SingleClassValueHandler } from '../handlers/single-class-value-handler';
 import { ClassProcessor } from '../class-processor';
 
 import FakerStatic = Faker.FakerStatic;
 import { Class } from 'src/types';
-import { Property } from '../property';
 import { PropertyDecoratorValue } from '../property-decorator-value';
 
 describe('SingleClassValueInspector Unit', () => {
   let handler: SingleClassValueHandler<Class>;
   const DTO_CLASS_VALUE = class TestClass {};
 
-  const property: IProperty<Class> = new Property(
+  const property: Property<Class> = new Property(
     'testPropertyName',
     'TestClass',
     new PropertyDecoratorValue(DTO_CLASS_VALUE)

--- a/src/handlers/single-class-value-handler.ts
+++ b/src/handlers/single-class-value-handler.ts
@@ -1,15 +1,15 @@
 import { ValueHandler } from '../types/value-handler.interface';
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { Class } from '../types/mock-options.type';
 import { isPrimitive } from '../common/is-primitive';
 import { AbstractValueHandler } from './abstract-value-handler';
 
 export class SingleClassValueHandler<P extends Class> extends AbstractValueHandler implements ValueHandler<P> {
-  public shouldHandle(property: IProperty<P>): boolean {
+  public shouldHandle(property: Property<P>): boolean {
     return property.decoratorValue.isFunction() && !isPrimitive(property.constructorName);
   }
 
-  public produceValue<T>(propertyDto: IProperty<P>): any {
+  public produceValue<T>(propertyDto: Property<P>): any {
     return this.classProcessor.process(propertyDto.decoratorValue.value as Class);
   }
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -1,12 +1,17 @@
 import { PropertyReflection } from '@plumier/reflect';
 import { MockOptions } from './types/mock-options.type';
-import { IProperty } from './types/iproperty.interface';
 import { PropertyDecoratorValue } from './property-decorator-value';
 
-export class Property<T extends MockOptions> implements IProperty<T> {
+export interface Property<T extends MockOptions> {
+  readonly name: string;
+  readonly constructorName: string;
+  readonly decoratorValue: PropertyDecoratorValue<T>;
+}
+
+export class Property<T extends MockOptions> implements Property<T> {
   constructor(
-    public readonly name,
-    public readonly constructorName,
+    public readonly name: string,
+    public readonly constructorName: string,
     public readonly decoratorValue: PropertyDecoratorValue<T>
   ) {}
   public static create(property: PropertyReflection, mockDecoratorValue: MockOptions | null): Property<MockOptions> {

--- a/src/types/class-reflection-dto.type.ts
+++ b/src/types/class-reflection-dto.type.ts
@@ -1,4 +1,4 @@
-import { IProperty } from '../types/iproperty.interface';
+import { Property } from '../property';
 import { MockOptions } from '../types/mock-options.type';
 
-export type ClassReflectionDto = IProperty<MockOptions>[];
+export type ClassReflectionDto = Property<MockOptions>[];

--- a/src/types/iclass-processor.interface.ts
+++ b/src/types/iclass-processor.interface.ts
@@ -1,6 +1,0 @@
-import { Class, ClassLiteral } from './mock-options.type';
-
-// eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IClassProcessor<T> {
-  process(target: Class<T>): ClassLiteral<T>;
-}

--- a/src/types/iproperty.interface.ts
+++ b/src/types/iproperty.interface.ts
@@ -1,9 +1,0 @@
-import { MockOptions } from './mock-options.type';
-import { PropertyDecoratorValue } from '../property-decorator-value';
-
-// eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IProperty<T extends MockOptions> {
-  name: string;
-  constructorName: string;
-  decoratorValue: PropertyDecoratorValue<T>;
-}


### PR DESCRIPTION
Merged interfaces starting with `I` prefix to have the same name as their class names